### PR TITLE
Add plan review notes and document gaps/ambiguities

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,5 @@
 {
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true,
-    "context7@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true
+    "feature-dev@claude-plugins-official": true
   }
 }

--- a/.claude/skills/cerebras/SKILL.md
+++ b/.claude/skills/cerebras/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cerebras-inference
+name: Cerebras Inference
 description: Use this to write code to call an LLM using LiteLLM and OpenRouter with the Cerebras inference provider
 ---
 

--- a/planning/MARKET_INTERFACE.md
+++ b/planning/MARKET_INTERFACE.md
@@ -1,0 +1,220 @@
+# Market Data Unified Interface
+
+This document describes the unified Python API for retrieving stock prices in FinAlly.
+The same interface works whether prices come from the Massive REST API or the built-in
+GBM simulator. All downstream code (SSE streaming, portfolio valuation, trade execution)
+reads from `PriceCache` and never touches the data source directly.
+
+---
+
+## Architecture
+
+```
+Environment variable check (MASSIVE_API_KEY)
+        │
+        ├── set & non-empty ──→ MassiveDataSource  (real market data, REST polling)
+        └── absent / empty  ──→ SimulatorDataSource (GBM simulation, no dependencies)
+                │
+                ▼ writes prices every tick
+           PriceCache  (thread-safe in-memory store)
+                │
+                ├──→ SSE stream  /api/stream/prices
+                ├──→ Portfolio valuation
+                └──→ Trade execution
+```
+
+---
+
+## Module Layout
+
+All code lives in `backend/app/market/`:
+
+| File               | Contents                                                     |
+|--------------------|--------------------------------------------------------------|
+| `models.py`        | `PriceUpdate` — the canonical price record                   |
+| `interface.py`     | `MarketDataSource` — abstract base class                     |
+| `cache.py`         | `PriceCache` — thread-safe price store                       |
+| `seed_prices.py`   | Starting prices and GBM parameters for all default tickers   |
+| `simulator.py`     | `GBMSimulator` + `SimulatorDataSource`                       |
+| `massive_client.py`| `MassiveDataSource`                                          |
+| `factory.py`       | `create_market_data_source()` — selects implementation       |
+| `stream.py`        | FastAPI SSE endpoint (`/api/stream/prices`)                  |
+
+Public re-exports via `__init__.py`:
+
+```python
+from app.market import PriceCache, PriceUpdate, create_market_data_source
+```
+
+---
+
+## Data Model: `PriceUpdate`
+
+Immutable frozen dataclass. Every price change is represented as one of these.
+
+```python
+@dataclass(frozen=True, slots=True)
+class PriceUpdate:
+    ticker: str
+    price: float
+    previous_price: float
+    timestamp: float          # Unix seconds
+
+    # Computed properties:
+    change: float             # price - previous_price
+    change_percent: float     # percentage change from previous_price
+    direction: str            # "up" | "down" | "flat"
+
+    def to_dict(self) -> dict:
+        """Serialize for JSON / SSE transmission."""
+```
+
+---
+
+## Abstract Interface: `MarketDataSource`
+
+```python
+class MarketDataSource(ABC):
+
+    async def start(self, tickers: list[str]) -> None:
+        """Begin producing prices. Starts a background task. Call once."""
+
+    async def stop(self) -> None:
+        """Stop the background task. Safe to call multiple times."""
+
+    async def add_ticker(self, ticker: str) -> None:
+        """Add a ticker to the active set. No-op if already present."""
+
+    async def remove_ticker(self, ticker: str) -> None:
+        """Remove a ticker. Also purges it from PriceCache."""
+
+    def get_tickers(self) -> list[str]:
+        """Return the current list of tracked tickers."""
+```
+
+Both `MassiveDataSource` and `SimulatorDataSource` implement this interface.
+Swapping one for the other requires no changes to any other module.
+
+---
+
+## PriceCache
+
+Thread-safe store. Producers call `update()`; consumers call `get()` / `get_all()`.
+
+```python
+class PriceCache:
+
+    def update(self, ticker: str, price: float, timestamp: float | None = None) -> PriceUpdate:
+        """Record a new price. Computes direction from previous value."""
+
+    def get(self, ticker: str) -> PriceUpdate | None:
+        """Latest PriceUpdate for one ticker, or None."""
+
+    def get_all(self) -> dict[str, PriceUpdate]:
+        """Snapshot of all current prices (shallow copy)."""
+
+    def get_price(self, ticker: str) -> float | None:
+        """Convenience: just the price float, or None."""
+
+    def remove(self, ticker: str) -> None:
+        """Remove a ticker from the cache."""
+
+    @property
+    def version(self) -> int:
+        """Monotonically increasing counter. Bumped on every update.
+        Used by the SSE endpoint for change detection (avoids re-sending unchanged prices)."""
+```
+
+---
+
+## Factory: Selecting the Implementation
+
+```python
+# backend/app/market/factory.py
+
+def create_market_data_source(price_cache: PriceCache) -> MarketDataSource:
+    api_key = os.environ.get("MASSIVE_API_KEY", "").strip()
+    if api_key:
+        return MassiveDataSource(api_key=api_key, price_cache=price_cache)
+    else:
+        return SimulatorDataSource(price_cache=price_cache)
+```
+
+The factory reads `MASSIVE_API_KEY` from the environment (loaded from `.env` at startup).
+
+---
+
+## Startup / Shutdown (FastAPI lifespan)
+
+```python
+from app.market import PriceCache, create_market_data_source
+
+cache = PriceCache()
+source = create_market_data_source(cache)
+
+# On startup:
+await source.start(["AAPL", "GOOGL", "MSFT", "AMZN", "TSLA",
+                    "NVDA", "META", "JPM", "V", "NFLX"])
+
+# On shutdown:
+await source.stop()
+```
+
+---
+
+## Reading Prices (downstream code)
+
+```python
+# Single ticker
+update = cache.get("AAPL")         # PriceUpdate | None
+price  = cache.get_price("AAPL")   # float | None
+
+# All tickers (e.g., for SSE broadcast or portfolio valuation)
+all_prices = cache.get_all()        # dict[str, PriceUpdate]
+
+# Access fields
+update.price
+update.previous_price
+update.change_percent
+update.direction    # "up" | "down" | "flat"
+update.to_dict()    # JSON-ready dict
+```
+
+---
+
+## Dynamic Watchlist
+
+The watchlist API routes call these methods when the user adds/removes tickers:
+
+```python
+await source.add_ticker("PYPL")    # starts tracking; cache has a price on next tick
+await source.remove_ticker("NFLX") # stops tracking; removes from cache immediately
+```
+
+---
+
+## SSE Stream
+
+`GET /api/stream/prices` — long-lived SSE connection. The server pushes all cached
+prices every 500 ms (or immediately when the version counter increments). Each event:
+
+```
+event: price
+data: {"ticker":"AAPL","price":190.25,"previous_price":190.10,"timestamp":1712345678.0,
+       "change":0.15,"change_percent":0.0789,"direction":"up"}
+```
+
+The frontend uses the native `EventSource` API; no library required.
+Reconnection is automatic via `EventSource`'s built-in retry mechanism.
+
+---
+
+## Environment Variables
+
+| Variable         | Effect                                                         |
+|------------------|----------------------------------------------------------------|
+| `MASSIVE_API_KEY`| Set to use real market data. Leave empty for the simulator.    |
+| (none)           | Simulator runs by default — no API key required.               |
+
+Poll interval for `MassiveDataSource` defaults to **15 seconds** (free tier safe).
+Simulator update interval defaults to **500 ms**.

--- a/planning/MARKET_SIMULATOR.md
+++ b/planning/MARKET_SIMULATOR.md
@@ -1,0 +1,198 @@
+# Market Simulator
+
+The GBM simulator generates realistic-looking stock price movements without any external
+API dependency. It is the default data source when `MASSIVE_API_KEY` is not set.
+
+---
+
+## Implementation Files
+
+| File             | Contents                                                      |
+|------------------|---------------------------------------------------------------|
+| `simulator.py`   | `GBMSimulator` (math engine) + `SimulatorDataSource` (async wrapper) |
+| `seed_prices.py` | Starting prices, per-ticker GBM parameters, correlation config |
+
+---
+
+## Mathematical Model: Geometric Brownian Motion
+
+Each tick advances every price by one GBM step:
+
+```
+S(t+dt) = S(t) * exp( (mu - sigma²/2) * dt  +  sigma * sqrt(dt) * Z )
+```
+
+Where:
+- `S(t)` — current price
+- `mu` — annualized drift (expected return, e.g. 0.05 = 5%/year)
+- `sigma` — annualized volatility (e.g. 0.22 = 22%/year for AAPL)
+- `dt` — time step as fraction of a trading year (~8.48×10⁻⁸ for 500 ms ticks)
+- `Z` — correlated standard normal random variable (see below)
+
+With `dt` this small, each tick produces sub-cent moves that accumulate naturally into
+realistic-looking drifts and swings over minutes and hours.
+
+---
+
+## Correlated Moves (Cholesky Decomposition)
+
+Stocks in the same sector tend to move together. The simulator models this via a
+correlation matrix and its Cholesky decomposition.
+
+**Correlation values:**
+
+| Relationship                     | Coefficient |
+|----------------------------------|-------------|
+| Same tech sector (AAPL, GOOGL…)  | 0.60        |
+| Same finance sector (JPM, V)     | 0.50        |
+| TSLA with anything               | 0.30        |
+| Cross-sector / unknown tickers   | 0.30        |
+
+**Per-tick generation:**
+
+```python
+z_independent = np.random.standard_normal(n)   # n = number of tickers
+z_correlated  = cholesky_matrix @ z_independent  # correlated draws
+```
+
+Each ticker `i` uses `z_correlated[i]` in the GBM formula instead of a raw normal draw.
+The Cholesky matrix is rebuilt whenever tickers are added or removed (O(n²), n < 50).
+
+---
+
+## Seed Prices and Per-Ticker Parameters
+
+Defined in `seed_prices.py`. These are the starting values when the simulator initialises:
+
+| Ticker | Seed Price | Volatility (σ) | Drift (μ) | Notes               |
+|--------|-----------|----------------|-----------|---------------------|
+| AAPL   | $190      | 22%            | 5%        |                     |
+| GOOGL  | $175      | 25%            | 5%        |                     |
+| MSFT   | $420      | 20%            | 5%        |                     |
+| AMZN   | $185      | 28%            | 5%        |                     |
+| TSLA   | $250      | 50%            | 3%        | High volatility      |
+| NVDA   | $800      | 40%            | 8%        | High vol, high drift |
+| META   | $500      | 30%            | 5%        |                     |
+| JPM    | $195      | 18%            | 4%        | Low vol (bank)       |
+| V      | $280      | 17%            | 4%        | Low vol (payments)   |
+| NFLX   | $600      | 35%            | 5%        |                     |
+
+Tickers added dynamically (not in the table above) use defaults: σ=25%, μ=5%, seed=random $50–$300.
+
+---
+
+## Random Shock Events
+
+On every tick, each ticker has a 0.1% chance of a sudden 2–5% price move (up or down).
+With 10 tickers at 2 ticks/second, expect roughly one shock event every 50 seconds.
+
+```python
+if random.random() < 0.001:
+    shock = random.uniform(0.02, 0.05)
+    sign  = random.choice([-1, 1])
+    price *= (1 + shock * sign)
+```
+
+This creates the visual drama of news-driven moves without modelling news.
+
+---
+
+## Class Structure
+
+### `GBMSimulator` (pure math, synchronous)
+
+```python
+class GBMSimulator:
+    def __init__(self, tickers: list[str], dt: float = DEFAULT_DT,
+                 event_probability: float = 0.001) -> None: ...
+
+    def step(self) -> dict[str, float]:
+        """Advance all tickers by one dt. Returns {ticker: new_price}.
+        Hot path — called every 500 ms."""
+
+    def add_ticker(self, ticker: str) -> None:
+        """Add ticker; rebuilds Cholesky matrix."""
+
+    def remove_ticker(self, ticker: str) -> None:
+        """Remove ticker; rebuilds Cholesky matrix."""
+
+    def get_price(self, ticker: str) -> float | None: ...
+    def get_tickers(self) -> list[str]: ...
+```
+
+`DEFAULT_DT = 0.5 / (252 * 6.5 * 3600)` — 500 ms expressed as a fraction of a trading year
+(252 trading days × 6.5 hours/day × 3600 s/hour = 5,896,800 trading seconds/year).
+
+### `SimulatorDataSource` (async wrapper, implements `MarketDataSource`)
+
+```python
+class SimulatorDataSource(MarketDataSource):
+    def __init__(self, price_cache: PriceCache,
+                 update_interval: float = 0.5,
+                 event_probability: float = 0.001) -> None: ...
+
+    async def start(self, tickers: list[str]) -> None:
+        """Create GBMSimulator, seed cache with initial prices, start background loop."""
+
+    async def stop(self) -> None:
+        """Cancel background task."""
+
+    async def add_ticker(self, ticker: str) -> None:
+        """Forward to GBMSimulator; seed cache immediately."""
+
+    async def remove_ticker(self, ticker: str) -> None:
+        """Forward to GBMSimulator; purge from PriceCache."""
+
+    async def _run_loop(self) -> None:
+        """Core loop: step() → write all prices to cache → sleep 500 ms."""
+```
+
+The background loop:
+
+```python
+while True:
+    prices = self._sim.step()                        # GBM math
+    for ticker, price in prices.items():
+        self._cache.update(ticker=ticker, price=price)  # write to cache
+    await asyncio.sleep(self._interval)              # 500 ms
+```
+
+---
+
+## Adding a New Ticker at Runtime
+
+```python
+# SimulatorDataSource.add_ticker() does this:
+self._sim.add_ticker(ticker)          # extend GBMSimulator state
+price = self._sim.get_price(ticker)   # get the seed price
+self._cache.update(ticker, price)     # immediately visible to SSE / portfolio
+```
+
+The new ticker appears in the next SSE broadcast (within 500 ms).
+
+---
+
+## "Daily Change" in the Simulator
+
+The simulator has no concept of market open/close, so "daily change" is defined as the
+percentage change from the **seed price** at process startup. The SSE payload always
+includes `previous_price` (price before the last tick), so the frontend can compute
+its own running change; the seed price itself is available in `seed_prices.py` for
+any backend calculation that needs a stable reference.
+
+---
+
+## Test Coverage
+
+The simulator is tested in `backend/tests/market/`:
+
+| Test module              | What it covers                                              |
+|--------------------------|-------------------------------------------------------------|
+| `test_simulator.py`      | GBM math validity, Cholesky structure, shock events, add/remove |
+| `test_simulator_source.py` | Async lifecycle, cache integration, dynamic ticker management |
+
+Run with:
+
+```bash
+cd backend && uv run pytest tests/market/test_simulator.py -v
+```

--- a/planning/MASSIVE_API.md
+++ b/planning/MASSIVE_API.md
@@ -1,0 +1,199 @@
+# Massive (formerly Polygon.io) API Reference
+
+Massive rebranded from Polygon.io on October 30, 2025. All existing API keys, accounts,
+and integrations continue to work unchanged. The Python SDK package is `massive`.
+
+---
+
+## Authentication
+
+```python
+from massive import RESTClient
+client = RESTClient(api_key="YOUR_MASSIVE_API_KEY")
+```
+
+The SDK wraps `https://api.polygon.io`. All raw HTTP calls require `?apiKey=<key>`.
+
+---
+
+## Endpoints Used by This Project
+
+### 1. Full Market Snapshot (primary polling endpoint)
+
+`GET /v2/snapshot/locale/us/markets/stocks/tickers`
+
+Fetches the latest price data for multiple tickers in a **single** request.
+This is the right endpoint for watchlist polling — one call covers all tickers.
+
+**Query parameters:**
+
+| Parameter     | Type              | Notes                                              |
+|---------------|-------------------|----------------------------------------------------|
+| `tickers`     | comma-sep string  | e.g. `AAPL,TSLA,NVDA`. Omit to get all US stocks. |
+| `include_otc` | boolean           | Include OTC securities; default `false`.           |
+
+**Response shape:**
+
+```json
+{
+  "count": 2,
+  "status": "OK",
+  "tickers": [
+    {
+      "ticker": "AAPL",
+      "todaysChange": 2.31,
+      "todaysChangePerc": 1.22,
+      "updated": 1712345678000,
+      "day":     { "o": 187.50, "h": 191.20, "l": 186.80, "c": 190.25, "v": 54321000, "vw": 189.10 },
+      "prevDay": { "o": 185.00, "h": 188.50, "l": 184.30, "c": 187.94, "v": 61200000, "vw": 186.75 },
+      "min":     { "o": 190.10, "h": 190.40, "l": 189.90, "c": 190.25, "v": 12340, "t": 1712345640000 },
+      "lastTrade": { "p": 190.25, "s": 100, "t": 1712345678000, "x": 4 },
+      "lastQuote": { "P": 190.26, "Q": 200, "p": 190.24, "S": 300, "t": 1712345679000 }
+    }
+  ]
+}
+```
+
+`lastTrade` fields: `p` = price, `s` = size, `t` = timestamp (Unix ms), `x` = exchange ID.
+`lastQuote` fields: `P` = ask price, `p` = bid price, `Q` = ask size, `S` = bid size.
+
+**Python SDK:**
+
+```python
+from massive import RESTClient
+from massive.rest.models import SnapshotMarketType
+
+client = RESTClient(api_key=api_key)
+
+# The RESTClient is synchronous — use asyncio.to_thread in async contexts
+snapshots = client.get_snapshot_all(
+    market_type=SnapshotMarketType.STOCKS,
+    tickers=["AAPL", "TSLA", "NVDA"],
+)
+
+for snap in snapshots:
+    price = snap.last_trade.price
+    ts = snap.last_trade.timestamp / 1000.0  # ms → seconds
+    change_pct = snap.todays_change_perc
+    print(f"{snap.ticker}: ${price:.2f}  ({change_pct:+.2f}%)")
+```
+
+**Rate limits:**
+
+| Plan      | Requests/min | Recommended poll interval |
+|-----------|--------------|---------------------------|
+| Free      | 5            | 15 s                      |
+| Starter   | 100          | 5 s                       |
+| Developer | 1 000        | 2 s                       |
+| Advanced  | unlimited    | < 1 s                     |
+
+Snapshot data clears at 3:30 AM EST and refreshes from ~4:00 AM EST.
+
+---
+
+### 2. Previous Day Bar (end-of-day reference price)
+
+`GET /v2/aggs/ticker/{ticker}/prev`
+
+Returns OHLCV for the last completed trading session. Used to compute the "daily change"
+percentage shown in the watchlist (today's price vs. yesterday's close).
+
+**Parameters:** `adjusted` (boolean, default `true`) — split-adjusted prices.
+
+**Response:**
+
+```json
+{
+  "ticker": "AAPL",
+  "status": "OK",
+  "results": [
+    { "T": "AAPL", "o": 185.00, "h": 188.50, "l": 184.30, "c": 187.94,
+      "v": 61200000, "vw": 186.75, "t": 1712188800000, "n": 523401 }
+  ]
+}
+```
+
+Fields: `T` = ticker, `o/h/l/c` = OHLC, `v` = volume, `vw` = VWAP,
+`t` = session start (Unix ms), `n` = transaction count.
+
+**Python SDK:**
+
+```python
+aggs = client.get_previous_close_agg(ticker="AAPL")
+prev_close = aggs[0].close   # float
+prev_open  = aggs[0].open    # float
+```
+
+---
+
+### 3. Single Ticker Snapshot
+
+`GET /v2/snapshot/locale/us/markets/stocks/tickers/{ticker}`
+
+Same shape as one element of the full snapshot. Useful for a quick price lookup
+on a single ticker without fetching the whole watchlist.
+
+---
+
+### 4. Last Trade
+
+`GET /v2/last/trade/{ticker}`
+
+Most recent trade tick. Lighter than a full snapshot.
+Note: timestamp `t` here is **nanoseconds** (unlike snapshot's milliseconds).
+
+```json
+{ "status": "OK", "results": { "T": "AAPL", "p": 190.25, "s": 100, "t": 1712345678000000000, "x": 4 } }
+```
+
+---
+
+## Async Usage Pattern (FastAPI)
+
+The Massive `RESTClient` is **synchronous**. Always wrap in `asyncio.to_thread`:
+
+```python
+import asyncio
+from massive import RESTClient
+from massive.rest.models import SnapshotMarketType
+
+client = RESTClient(api_key=api_key)
+
+snapshots = await asyncio.to_thread(
+    client.get_snapshot_all,
+    market_type=SnapshotMarketType.STOCKS,
+    tickers=["AAPL", "NVDA"],
+)
+```
+
+---
+
+## Error Handling
+
+| HTTP | Meaning                                  |
+|------|------------------------------------------|
+| 401  | Invalid/missing API key                  |
+| 403  | Endpoint requires a higher plan          |
+| 404  | Ticker not found                         |
+| 429  | Rate limit exceeded — back off and retry |
+
+Standard pattern: catch broadly, log, and let the poll loop retry:
+
+```python
+try:
+    snapshots = client.get_snapshot_all(
+        market_type=SnapshotMarketType.STOCKS,
+        tickers=tickers,
+    )
+except Exception as e:
+    logger.error("Massive poll failed: %s", e)
+    # Don't re-raise — the background loop will retry on the next interval
+```
+
+---
+
+## Installation
+
+```bash
+uv add massive
+```

--- a/planning/PLAN.md
+++ b/planning/PLAN.md
@@ -454,3 +454,46 @@ The container is designed to deploy to AWS App Runner, Render, or any container 
 - Portfolio visualization: heatmap renders with correct colors, P&L chart has data points
 - AI chat (mocked): send a message, receive a response, trade execution appears inline
 - SSE resilience: disconnect and verify reconnection
+
+---
+
+## 13. Document Review Notes
+
+### Gaps & Ambiguities
+
+**§6 SSE Streaming — "all tickers known to the system"**
+The SSE endpoint streams prices for "all tickers known to the system." It's unclear whether this means the watchlist only, or all tickers ever cached (including tickers from positions in stocks no longer on the watchlist). This matters when a user holds a position in a delisted watchlist item. Recommend clarifying: SSE streams the union of watchlist + current positions.
+
+**§8 API — no response shape docs**
+The endpoint table describes inputs but not response shapes. Agents implementing the frontend and backend will need to infer or invent these independently. At minimum, `GET /api/portfolio` and `POST /api/chat` response schemas should be documented here, as they're complex enough to cause integration mismatches.
+
+**§9 LLM — chat history window**
+"Loads recent conversation history" — how many messages? No limit is specified. Without a bound, a long session will grow the prompt indefinitely and eventually hit context limits. Recommend specifying a number (e.g., last 20 messages).
+
+**§9 LLM — failed trade feedback loop**
+"If a trade fails validation, the error is included in the chat response" — but the response has already been returned to the frontend at that point. Clarify whether validation happens before or after the LLM call, and whether the LLM response `message` is regenerated to include the error, or whether the backend appends an error annotation. Currently ambiguous.
+
+**§7 Database — `portfolio_snapshots` growth**
+Snapshots accumulate every 30 seconds indefinitely. For a long-running demo session this grows unbounded. The P&L chart doesn't need every data point. Recommend specifying a retention policy (e.g., keep last 24 hours, or downsample after N points).
+
+**§10 Frontend — "daily change %"**
+The watchlist panel should show "daily change %" but the simulator doesn't have a concept of a daily open price — it just uses GBM from startup. Clarify what "daily change" means for the simulator: change since process start? Change from seed price? This affects both the backend SSE payload and frontend display.
+
+### Inconsistencies
+
+**§4 vs §11 — Dockerfile path for static files**
+§4 shows `backend/db/` containing schema SQL. §11 says the Dockerfile copies `frontend build output into a static/ directory` (inside the container), but doesn't say where relative to `/app`. The `docker run` command in §11 only mounts `/app/db`. If static files land at `/app/static/` and FastAPI needs to serve them, the path assumption should be made explicit in the Dockerfile pseudocode.
+
+**§9 — Model name**
+`openrouter/openai/gpt-oss-120b` doesn't match any known OpenRouter model identifier. The cerebras-inference skill likely uses a different model string. This will cause a runtime error for any agent who follows the plan literally. The exact model ID should be taken from the cerebras skill.
+
+### Minor Issues
+
+**§11 Dockerfile — missing lockfile copy**
+`uv sync` requires `uv.lock` to be present. The pseudocode only shows `Copy backend/` — this works if the lockfile is inside `backend/`, but it should be explicit since forgetting the lockfile is a common Docker mistake.
+
+**§2 — Sparklines reset on page refresh**
+Sparklines "accumulated from SSE since page load" are ephemeral by design, but this means they're always empty on first load. Worth a one-line note so the frontend engineer doesn't try to persist or pre-populate them from the API.
+
+**§12 — E2E test gap: LLM mock content undefined**
+The E2E tests use `LLM_MOCK=true` and test "trade execution appears inline" — but nowhere in the plan is the mock response content specified. The backend must return a deterministic mock that includes at least one trade for the test to pass. The mock payload should be documented (even briefly) so backend and E2E test implementations agree.

--- a/planning/REVIEW.md
+++ b/planning/REVIEW.md
@@ -1,0 +1,200 @@
+# Review of `planning/PLAN.md`
+
+## Overall Feedback
+
+This is a strong project plan. It has a clear product vision, a coherent architecture, and a good explanation for why the main technology choices were made. That is already better than many early project plans.
+
+The main issue is not that the plan is weak. The main issue is that it is ambitious. For a junior developer, the current document explains **what** the product should be, but it does not always explain **in what order to build it**, **what can be simplified first**, and **what exact contracts different parts of the system should follow**.
+
+In short: the plan is exciting and well-scoped at the product level, but it still needs more implementation-level guidance.
+
+## What Is Working Well
+
+- The vision is easy to understand and gives the project a strong identity.
+- The architecture choices are mostly sensible for a teaching project: FastAPI, SQLite, SSE, one container, one port.
+- The plan correctly avoids unnecessary complexity in some places, especially by using market orders only and defaulting to a simulator.
+- The testing section is a good sign. It shows that quality was considered early.
+- The built-in review notes in Section 13 are useful and catch several real gaps.
+
+## Main Suggestions for Improvement
+
+### 1. Define a clear MVP before the “full demo” version
+
+Right now the plan mixes core requirements and “wow factor” features together. That makes implementation riskier.
+
+For a junior developer, I would strongly recommend splitting the work into:
+
+- **MVP**: watchlist, streaming prices, manual buy/sell, portfolio summary, simple chat request/response
+- **Phase 2**: treemap, richer charts, watchlist management through AI, better animations
+- **Phase 3 / stretch**: cloud deployment, more polished mock behavior, advanced charting improvements
+
+This matters because a good software plan should make it obvious what can be cut if time runs short.
+
+### 2. Add a milestone-based implementation order
+
+The document describes the final product well, but not the build sequence.
+
+That is important for a junior developer because they need a safe path like:
+
+1. Create backend health check and static frontend serving
+2. Set up SQLite schema and seed data
+3. Implement simulator and in-memory price cache
+4. Add SSE stream and verify prices update in browser
+5. Implement manual trade API and portfolio calculations
+6. Build basic frontend watchlist and portfolio table
+7. Add chat endpoint with `LLM_MOCK=true`
+8. Integrate real LLM only after mock mode works
+9. Add charts, treemap, and UI polish last
+
+Without this order, it is easy to start with the flashy parts and get blocked by the fundamentals.
+
+### 3. Define API response shapes, not just endpoint names
+
+This is one of the biggest practical gaps.
+
+A frontend developer and a backend developer can both follow the current plan and still build incompatible implementations. The plan should include example JSON responses for at least:
+
+- `GET /api/portfolio`
+- `GET /api/watchlist`
+- `GET /api/portfolio/history`
+- `POST /api/portfolio/trade`
+- `POST /api/chat`
+
+For a junior developer, explicit contracts reduce confusion and rework.
+
+### 4. Resolve open questions inside the plan, not only in the review notes
+
+Section 13 identifies good problems, but they are still left as open issues. A stronger version of the plan would move the decisions back into the earlier sections.
+
+Examples:
+
+- What exactly is included in SSE: watchlist only, or watchlist + held positions?
+- How many chat messages are included in LLM history?
+- What does “daily change %” mean in simulator mode?
+- What is the exact mock chat response used in tests?
+
+A plan is more helpful when it contains decisions, not just observations.
+
+### 5. Simplify the LLM scope and describe failure behavior more carefully
+
+The AI assistant is one of the riskiest parts of the project because it combines prompting, structured outputs, validation, side effects, and UI updates.
+
+For a junior developer, I would suggest narrowing the first version:
+
+- Start with chat that returns a message only
+- Then add structured watchlist actions
+- Then add structured trade actions
+- Only after that allow auto-execution
+
+If auto-execution stays in scope from day one, the plan should clearly define:
+
+- what happens when the model returns invalid JSON
+- what happens when only some requested trades succeed
+- whether the backend edits the assistant message after validation fails
+- what response shape the frontend receives for partial success
+
+### 6. Add explicit trade and portfolio rules
+
+The plan describes the database schema, but some business rules are still implicit.
+
+For example, the plan should answer these directly:
+
+- Are fractional shares allowed everywhere in the UI and API?
+- How many decimal places are supported?
+- How is average cost recalculated after multiple buys?
+- What happens when selling the entire position?
+- Are negative or zero quantities rejected with `400 Bad Request`?
+- Are unknown tickers allowed if they are not already in the watchlist?
+
+Junior developers often struggle less with coding than with unclear business rules.
+
+### 7. Add error states and empty states to the UX section
+
+The user experience section focuses on the ideal path, which is good, but implementation also needs non-happy-path behavior.
+
+The plan should describe:
+
+- what the UI shows when SSE disconnects
+- what happens if the market data provider is unavailable
+- what happens if the chat request fails
+- what the portfolio area shows when there are no positions
+- what the chart shows before enough data exists
+
+These states are easy to forget and often create rough demos.
+
+### 8. Reduce accidental complexity in persistence
+
+The snapshot idea is useful, but the retention policy should be defined now. Otherwise the table can grow forever.
+
+A simple rule would be enough:
+
+- keep snapshots for the last 24 hours, or
+- keep the latest N rows, or
+- store every 30 seconds for 30 minutes, then downsample older data
+
+The important thing is to choose a rule before implementation.
+
+### 9. Make the testing plan more priority-driven
+
+The testing section is good, but still broad. A junior developer benefits from knowing which tests matter most.
+
+I would recommend stating a minimum required test set:
+
+- one backend test for trade validation
+- one backend test for portfolio calculation
+- one backend test for simulator output format
+- one E2E test for first launch
+- one E2E test for manual buy flow
+- one E2E test for mocked chat flow
+
+This gives a realistic testing floor before adding more coverage.
+
+### 10. Fix a few inconsistencies before anyone starts coding
+
+These are small, but they can waste time:
+
+- The model identifier in the LLM section should be verified before implementation.
+- The Docker section should explicitly describe where the built frontend files live in the final image.
+- The Docker steps should clearly mention `uv.lock`.
+- The plan should state whether sparkline data is intentionally temporary and reset on page refresh.
+
+## Suggested Additions
+
+If this plan is going to guide implementation, I would add three short sections:
+
+### A. Non-Goals
+
+This helps prevent scope creep. For example:
+
+- No real-money trading
+- No authentication or multi-user support in v1
+- No order book or limit orders
+- No portfolio import/export
+
+### B. Definition of Done
+
+This helps a junior developer know when the project is actually complete. For example:
+
+- App starts with one documented command
+- Default watchlist loads
+- Prices update without manual refresh
+- User can buy and sell successfully
+- Portfolio values update correctly
+- Chat works in mock mode
+- E2E tests pass
+
+### C. Implementation Milestones
+
+A short milestone table would make this much easier to execute and review.
+
+## Final Recommendation
+
+I would not rewrite the whole plan. The foundation is solid. I would do a focused revision with these goals:
+
+1. Separate MVP from stretch features
+2. Add milestone order
+3. Add response schemas and business rules
+4. Resolve Section 13 ambiguities directly in the main sections
+5. Reduce LLM ambiguity and define failure handling
+
+If those changes are made, this will become much easier for a junior developer to implement successfully and much less likely to produce mismatched frontend/backend work.


### PR DESCRIPTION
## Summary

- Appends §13 to `planning/PLAN.md` with identified gaps, inconsistencies, and minor issues found during review
- Adds `planning/REVIEW.md` — a detailed structured review covering MVP phasing, API response contracts, LLM failure handling, business rules, and recommended implementation order
- Updates enabled Claude Code plugins in `.claude/settings.json`
- Fixes cerebras skill name casing in `.claude/skills/cerebras/SKILL.md`

## Test plan

- [ ] Review `planning/REVIEW.md` for accuracy and completeness
- [ ] Confirm `planning/PLAN.md` §13 matches the summary in REVIEW.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)