### PR TITLE
Fix must-fix market data review items (C1, H1, H2, H4)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -17,15 +17,19 @@ from app.market import PriceCache, PriceUpdate, MarketDataSource, create_market_
 
 ### Core Types
 
-- **`PriceUpdate`** — Immutable dataclass: `ticker`, `price`, `previous_price`, `timestamp`, plus properties `change`, `change_percent`, `direction` ("up"/"down"/"flat"), and `to_dict()` for JSON serialization.
+- **`PriceUpdate`** — Immutable dataclass: `ticker`, `price`, `previous_price`, `day_open`, `timestamp`, plus properties:
+  - `change` / `change_percent` / `direction` ("up"/"down"/"flat") — vs the **previous tick**; drives the price-flash animation.
+  - `day_change` / `day_change_percent` — vs **`day_open`** (the session/day open); this is the **"daily change %"** the watchlist shows.
+  - `to_dict()` — JSON serialization; emits all of the above keys plus `day_open`.
 
 - **`PriceCache`** — Thread-safe in-memory store. Key methods:
-  - `update(ticker, price, timestamp=None) -> PriceUpdate`
+  - `update(ticker, price, timestamp=None, day_open=None) -> PriceUpdate` — `day_open`: if provided (Massive snapshot's day open / prev close), used as-is; otherwise carried forward from the prior tick; on the first tick it defaults to `price` (the simulator's session open).
   - `get(ticker) -> PriceUpdate | None`
   - `get_price(ticker) -> float | None`
   - `get_all() -> dict[str, PriceUpdate]`
+  - `snapshot() -> tuple[int, dict[str, PriceUpdate]]` — atomic `(version, prices-copy)` under one lock; use this (not `version` + `get_all()`) for SSE change detection to avoid torn reads.
   - `remove(ticker)`
-  - `version` property — monotonic counter, increments on every update (for SSE change detection)
+  - `version` property — monotonic counter, increments on every update
 
 - **`MarketDataSource`** — Abstract interface implemented by `SimulatorDataSource` and `MassiveDataSource`. Lifecycle: `start(tickers)` -> `add_ticker()` / `remove_ticker()` -> `stop()`.
 
@@ -39,6 +43,8 @@ from app.market import create_stream_router
 router = create_stream_router(price_cache)  # Returns FastAPI APIRouter
 # Endpoint: GET /api/stream/prices (text/event-stream)
 ```
+
+Each `data:` frame is a JSON map of `{ticker: PriceUpdate.to_dict()}` for all tracked tickers, sent on change (~500ms cadence). A `: keep-alive` comment is emitted if no update goes out for 15s so idle connections aren't reaped by proxies/browsers.
 
 ### Seed Data
 

--- a/backend/app/market/cache.py
+++ b/backend/app/market/cache.py
@@ -20,21 +20,42 @@ class PriceCache:
         self._lock = Lock()
         self._version: int = 0  # Monotonically increasing; bumped on every update
 
-    def update(self, ticker: str, price: float, timestamp: float | None = None) -> PriceUpdate:
+    def update(
+        self,
+        ticker: str,
+        price: float,
+        timestamp: float | None = None,
+        day_open: float | None = None,
+    ) -> PriceUpdate:
         """Record a new price for a ticker. Returns the created PriceUpdate.
 
         Automatically computes direction and change from the previous price.
         If this is the first update for the ticker, previous_price == price (direction='flat').
+
+        ``day_open`` is the session/day open used for the "daily change %" metric:
+          - If provided (e.g. the Massive snapshot's day open), it is used as-is.
+          - Otherwise it carries forward from the prior tick, so it stays stable
+            across the session.
+          - On the very first update for a ticker it defaults to ``price`` — i.e.
+            the simulator's session-open price.
         """
         with self._lock:
             ts = timestamp or time.time()
             prev = self._prices.get(ticker)
             previous_price = prev.price if prev else price
 
+            if day_open is not None:
+                resolved_day_open = day_open
+            elif prev is not None:
+                resolved_day_open = prev.day_open
+            else:
+                resolved_day_open = price
+
             update = PriceUpdate(
                 ticker=ticker,
                 price=round(price, 2),
                 previous_price=round(previous_price, 2),
+                day_open=round(resolved_day_open, 2),
                 timestamp=ts,
             )
             self._prices[ticker] = update
@@ -50,6 +71,16 @@ class PriceCache:
         """Snapshot of all current prices. Returns a shallow copy."""
         with self._lock:
             return dict(self._prices)
+
+    def snapshot(self) -> tuple[int, dict[str, PriceUpdate]]:
+        """Atomically read the version counter and a copy of all prices.
+
+        Returns ``(version, {ticker: PriceUpdate})`` under a single lock so the
+        version and the data it describes can never be torn apart by a
+        concurrent ``update()``. SSE streaming uses this for change detection.
+        """
+        with self._lock:
+            return self._version, dict(self._prices)
 
     def get_price(self, ticker: str) -> float | None:
         """Convenience: get just the price float, or None."""

--- a/backend/app/market/massive_client.py
+++ b/backend/app/market/massive_client.py
@@ -98,16 +98,33 @@ class MassiveDataSource(MarketDataSource):
             processed = 0
             for snap in snapshots:
                 try:
-                    price = snap.last_trade.price
-                    # Massive timestamps are Unix milliseconds → convert to seconds
-                    timestamp = snap.last_trade.timestamp / 1000.0
+                    last_trade = snap.last_trade
+                    price = last_trade.price
+                    if price is None:
+                        raise ValueError("snapshot has no last-trade price")
+
+                    # Polygon/Massive trade timestamps are Unix NANOSECONDS
+                    # (SIP, falling back to the participant feed). Convert to
+                    # seconds; if absent, let the cache stamp it with now().
+                    raw_ts = last_trade.sip_timestamp or last_trade.participant_timestamp
+                    timestamp = raw_ts / 1_000_000_000.0 if raw_ts else None
+
+                    # Daily open for "daily change %": today's open, falling
+                    # back to the prior session's close before the market opens.
+                    day_open = None
+                    if snap.day is not None and snap.day.open:
+                        day_open = snap.day.open
+                    elif snap.prev_day is not None and snap.prev_day.close:
+                        day_open = snap.prev_day.close
+
                     self._cache.update(
                         ticker=snap.ticker,
                         price=price,
                         timestamp=timestamp,
+                        day_open=day_open,
                     )
                     processed += 1
-                except (AttributeError, TypeError) as e:
+                except (AttributeError, TypeError, ValueError) as e:
                     logger.warning(
                         "Skipping snapshot for %s: %s",
                         getattr(snap, "ticker", "???"),

--- a/backend/app/market/massive_client.py
+++ b/backend/app/market/massive_client.py
@@ -48,7 +48,7 @@ class MassiveDataSource(MarketDataSource):
         self._task = asyncio.create_task(self._poll_loop(), name="massive-poller")
         logger.info(
             "Massive poller started: %d tickers, %.1fs interval",
-            len(tickers),
+            len(self._tickers),
             self._interval,
         )
 
@@ -92,9 +92,11 @@ class MassiveDataSource(MarketDataSource):
             return
 
         try:
-            # The Massive RESTClient is synchronous — run in a thread to
-            # avoid blocking the event loop.
-            snapshots = await asyncio.to_thread(self._fetch_snapshots)
+            # The Massive RESTClient is synchronous — run in a thread to avoid
+            # blocking the event loop. Snapshot the ticker list first so a
+            # concurrent add/remove can't mutate it mid-fetch.
+            tickers = list(self._tickers)
+            snapshots = await asyncio.to_thread(self._fetch_snapshots, tickers)
             processed = 0
             for snap in snapshots:
                 try:
@@ -130,16 +132,16 @@ class MassiveDataSource(MarketDataSource):
                         getattr(snap, "ticker", "???"),
                         e,
                     )
-            logger.debug("Massive poll: updated %d/%d tickers", processed, len(self._tickers))
+            logger.debug("Massive poll: updated %d/%d tickers", processed, len(tickers))
 
         except Exception as e:
             logger.error("Massive poll failed: %s", e)
             # Don't re-raise — the loop will retry on the next interval.
             # Common failures: 401 (bad key), 429 (rate limit), network errors.
 
-    def _fetch_snapshots(self) -> list:
+    def _fetch_snapshots(self, tickers: list[str]) -> list:
         """Synchronous call to the Massive REST API. Runs in a thread."""
         return self._client.get_snapshot_all(
             market_type=SnapshotMarketType.STOCKS,
-            tickers=self._tickers,
+            tickers=tickers,
         )

--- a/backend/app/market/models.py
+++ b/backend/app/market/models.py
@@ -8,28 +8,48 @@ from dataclasses import dataclass, field
 
 @dataclass(frozen=True, slots=True)
 class PriceUpdate:
-    """Immutable snapshot of a single ticker's price at a point in time."""
+    """Immutable snapshot of a single ticker's price at a point in time.
+
+    Two reference points are tracked:
+      - ``previous_price`` — the immediately preceding tick. Drives the
+        green/red flash animation (``change`` / ``direction``).
+      - ``day_open`` — the session/day open price, held stable across ticks.
+        Drives the watchlist's "daily change %" (``day_change_percent``).
+    """
 
     ticker: str
     price: float
     previous_price: float
+    day_open: float
     timestamp: float = field(default_factory=time.time)  # Unix seconds
 
     @property
     def change(self) -> float:
-        """Absolute price change from previous update."""
+        """Absolute price change from the previous tick."""
         return round(self.price - self.previous_price, 4)
 
     @property
     def change_percent(self) -> float:
-        """Percentage change from previous update."""
+        """Percentage change from the previous tick."""
         if self.previous_price == 0:
             return 0.0
         return round((self.price - self.previous_price) / self.previous_price * 100, 4)
 
     @property
+    def day_change(self) -> float:
+        """Absolute price change since the day/session open."""
+        return round(self.price - self.day_open, 4)
+
+    @property
+    def day_change_percent(self) -> float:
+        """Percentage change since the day/session open (the watchlist metric)."""
+        if self.day_open == 0:
+            return 0.0
+        return round((self.price - self.day_open) / self.day_open * 100, 4)
+
+    @property
     def direction(self) -> str:
-        """'up', 'down', or 'flat'."""
+        """'up', 'down', or 'flat' relative to the previous tick."""
         if self.price > self.previous_price:
             return "up"
         elif self.price < self.previous_price:
@@ -42,8 +62,11 @@ class PriceUpdate:
             "ticker": self.ticker,
             "price": self.price,
             "previous_price": self.previous_price,
+            "day_open": self.day_open,
             "timestamp": self.timestamp,
             "change": self.change,
             "change_percent": self.change_percent,
+            "day_change": self.day_change,
+            "day_change_percent": self.day_change_percent,
             "direction": self.direction,
         }

--- a/backend/app/market/stream.py
+++ b/backend/app/market/stream.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from collections.abc import AsyncGenerator
 
 from fastapi import APIRouter, Request
@@ -52,16 +53,21 @@ async def _generate_events(
     price_cache: PriceCache,
     request: Request,
     interval: float = 0.5,
+    heartbeat: float = 15.0,
 ) -> AsyncGenerator[str, None]:
     """Async generator that yields SSE-formatted price events.
 
-    Sends all prices every `interval` seconds. Stops when the client
-    disconnects (detected via request.is_disconnected()).
+    Sends all prices every `interval` seconds when they change. If no update
+    has been sent for `heartbeat` seconds (prices flat, source idle, etc.), a
+    comment ping is emitted to keep the connection alive through proxies and
+    browsers that drop idle event-streams. Stops when the client disconnects
+    (detected via request.is_disconnected()).
     """
     # Tell the client to retry after 1 second if the connection drops
     yield "retry: 1000\n\n"
 
     last_version = -1
+    last_send = time.monotonic()
     client_ip = request.client.host if request.client else "unknown"
     logger.info("SSE client connected: %s", client_ip)
 
@@ -72,16 +78,23 @@ async def _generate_events(
                 logger.info("SSE client disconnected: %s", client_ip)
                 break
 
-            current_version = price_cache.version
+            # Atomic (version, prices) read so they can't be torn apart by a
+            # concurrent cache update.
+            current_version, prices = price_cache.snapshot()
             if current_version != last_version:
                 last_version = current_version
-                prices = price_cache.get_all()
-
                 if prices:
                     data = {ticker: update.to_dict() for ticker, update in prices.items()}
                     payload = json.dumps(data)
                     yield f"data: {payload}\n\n"
+                    last_send = time.monotonic()
+            elif time.monotonic() - last_send >= heartbeat:
+                # Keep-alive comment — ignored by EventSource, but keeps the
+                # TCP/proxy connection from being reaped while prices are flat.
+                yield ": keep-alive\n\n"
+                last_send = time.monotonic()
 
             await asyncio.sleep(interval)
     except asyncio.CancelledError:
         logger.info("SSE stream cancelled for: %s", client_ip)
+        raise

--- a/backend/tests/market/test_cache.py
+++ b/backend/tests/market/test_cache.py
@@ -1,5 +1,7 @@
 """Tests for PriceCache."""
 
+import pytest
+
 from app.market.cache import PriceCache
 
 
@@ -65,6 +67,43 @@ class TestPriceCache:
         assert cache.version == v0 + 1
         cache.update("AAPL", 191.00)
         assert cache.version == v0 + 2
+
+    def test_day_open_defaults_to_first_price(self):
+        """First update for a ticker uses its price as the session open."""
+        cache = PriceCache()
+        update = cache.update("AAPL", 190.00)
+        assert update.day_open == 190.00
+
+    def test_day_open_carries_forward(self):
+        """day_open stays stable across ticks so daily % is meaningful."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        update = cache.update("AAPL", 195.00)
+        assert update.day_open == 190.00  # not the previous tick (190.00 here)
+        assert update.day_change == 5.00
+        assert update.day_change_percent == pytest.approx(2.6316, abs=1e-4)
+
+    def test_day_open_explicit_override(self):
+        """An explicit day_open (e.g. from Massive) is used and carried forward."""
+        cache = PriceCache()
+        cache.update("AAPL", 191.00, day_open=188.00)
+        first = cache.get("AAPL")
+        assert first.day_open == 188.00
+        # Subsequent tick without an explicit day_open keeps the same open.
+        update = cache.update("AAPL", 192.00)
+        assert update.day_open == 188.00
+
+    def test_snapshot_returns_version_and_prices(self):
+        """snapshot() returns the current version paired with a copy of prices."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        cache.update("GOOGL", 175.00)
+        version, prices = cache.snapshot()
+        assert version == cache.version
+        assert set(prices.keys()) == {"AAPL", "GOOGL"}
+        # Mutating the returned dict must not affect the cache.
+        prices.clear()
+        assert len(cache) == 2
 
     def test_get_price_convenience(self):
         """Test the convenience get_price method."""

--- a/backend/tests/market/test_massive.py
+++ b/backend/tests/market/test_massive.py
@@ -7,14 +7,35 @@ import pytest
 from app.market.cache import PriceCache
 from app.market.massive_client import MassiveDataSource
 
+# A realistic SIP timestamp in NANOSECONDS (2024-02-10T15:20:00Z),
+# i.e. 1707578400 seconds.
+SIP_TS_NS = 1_707_578_400_000_000_000
+SIP_TS_SECONDS = 1_707_578_400.0
 
-def _make_snapshot(ticker: str, price: float, timestamp_ms: int) -> MagicMock:
-    """Create a mock Massive snapshot object."""
+
+def _make_snapshot(
+    ticker: str,
+    price: float,
+    sip_timestamp_ns: int = SIP_TS_NS,
+    day_open: float | None = None,
+    prev_close: float | None = None,
+) -> MagicMock:
+    """Create a mock Massive snapshot mirroring the real TickerSnapshot shape.
+
+    The real ``LastTrade`` model has no ``timestamp`` attribute — it exposes
+    ``sip_timestamp`` / ``participant_timestamp`` in nanoseconds. ``day`` and
+    ``prev_day`` are ``Agg`` objects carrying ``open`` / ``close``.
+    """
     snap = MagicMock()
     snap.ticker = ticker
     snap.last_trade = MagicMock()
     snap.last_trade.price = price
-    snap.last_trade.timestamp = timestamp_ms
+    snap.last_trade.sip_timestamp = sip_timestamp_ns
+    snap.last_trade.participant_timestamp = sip_timestamp_ns
+    snap.day = MagicMock()
+    snap.day.open = day_open
+    snap.prev_day = MagicMock()
+    snap.prev_day.close = prev_close
     return snap
 
 
@@ -34,8 +55,8 @@ class TestMassiveDataSource:
         source._client = MagicMock()  # Satisfy the _poll_once guard
 
         mock_snapshots = [
-            _make_snapshot("AAPL", 190.50, 1707580800000),
-            _make_snapshot("GOOGL", 175.25, 1707580800000),
+            _make_snapshot("AAPL", 190.50),
+            _make_snapshot("GOOGL", 175.25),
         ]
 
         with patch.object(source, "_fetch_snapshots", return_value=mock_snapshots):
@@ -55,7 +76,7 @@ class TestMassiveDataSource:
         source._tickers = ["AAPL", "BAD"]
         source._client = MagicMock()  # Satisfy the _poll_once guard
 
-        good_snap = _make_snapshot("AAPL", 190.50, 1707580800000)
+        good_snap = _make_snapshot("AAPL", 190.50)
         bad_snap = MagicMock()
         bad_snap.ticker = "BAD"
         bad_snap.last_trade = None  # Will cause AttributeError
@@ -84,7 +105,7 @@ class TestMassiveDataSource:
         assert cache.get_price("AAPL") is None  # No update happened
 
     async def test_timestamp_conversion(self):
-        """Test that timestamps are converted from milliseconds to seconds."""
+        """SIP timestamps are converted from nanoseconds to seconds."""
         cache = PriceCache()
         source = MassiveDataSource(
             api_key="test-key",
@@ -94,14 +115,61 @@ class TestMassiveDataSource:
         source._tickers = ["AAPL"]
         source._client = MagicMock()  # Satisfy the _poll_once guard
 
-        mock_snapshots = [_make_snapshot("AAPL", 190.50, 1707580800000)]
+        mock_snapshots = [_make_snapshot("AAPL", 190.50, sip_timestamp_ns=SIP_TS_NS)]
 
         with patch.object(source, "_fetch_snapshots", return_value=mock_snapshots):
             await source._poll_once()
 
         update = cache.get("AAPL")
         assert update is not None
-        assert update.timestamp == 1707580800.0  # Converted to seconds
+        assert update.timestamp == SIP_TS_SECONDS  # nanoseconds → seconds
+
+    async def test_participant_timestamp_fallback(self):
+        """Falls back to participant_timestamp when sip_timestamp is missing."""
+        cache = PriceCache()
+        source = MassiveDataSource(api_key="test-key", price_cache=cache, poll_interval=60.0)
+        source._tickers = ["AAPL"]
+        source._client = MagicMock()
+
+        snap = _make_snapshot("AAPL", 190.50)
+        snap.last_trade.sip_timestamp = None
+        snap.last_trade.participant_timestamp = SIP_TS_NS
+
+        with patch.object(source, "_fetch_snapshots", return_value=[snap]):
+            await source._poll_once()
+
+        assert cache.get("AAPL").timestamp == SIP_TS_SECONDS
+
+    async def test_day_open_from_snapshot(self):
+        """day_open is taken from the snapshot's day.open for daily change %."""
+        cache = PriceCache()
+        source = MassiveDataSource(api_key="test-key", price_cache=cache, poll_interval=60.0)
+        source._tickers = ["AAPL"]
+        source._client = MagicMock()
+
+        mock_snapshots = [_make_snapshot("AAPL", 195.00, day_open=190.00)]
+
+        with patch.object(source, "_fetch_snapshots", return_value=mock_snapshots):
+            await source._poll_once()
+
+        update = cache.get("AAPL")
+        assert update.day_open == 190.00
+        assert update.day_change_percent == pytest.approx(2.6316, abs=1e-4)
+
+    async def test_day_open_falls_back_to_prev_close(self):
+        """Before the open, prev_day.close stands in for the day open."""
+        cache = PriceCache()
+        source = MassiveDataSource(api_key="test-key", price_cache=cache, poll_interval=60.0)
+        source._tickers = ["AAPL"]
+        source._client = MagicMock()
+
+        # day.open is None (pre-market); prev_day.close should be used.
+        mock_snapshots = [_make_snapshot("AAPL", 195.00, day_open=None, prev_close=189.00)]
+
+        with patch.object(source, "_fetch_snapshots", return_value=mock_snapshots):
+            await source._poll_once()
+
+        assert cache.get("AAPL").day_open == 189.00
 
     async def test_add_ticker(self):
         """Test adding a ticker."""
@@ -189,7 +257,7 @@ class TestMassiveDataSource:
         cache = PriceCache()
         source = MassiveDataSource(api_key="test-key", price_cache=cache, poll_interval=60.0)
 
-        mock_snapshots = [_make_snapshot("AAPL", 190.50, 1707580800000)]
+        mock_snapshots = [_make_snapshot("AAPL", 190.50)]
 
         with patch("app.market.massive_client.RESTClient"):
             with patch.object(source, "_fetch_snapshots", return_value=mock_snapshots):

--- a/backend/tests/market/test_models.py
+++ b/backend/tests/market/test_models.py
@@ -10,68 +10,118 @@ class TestPriceUpdate:
 
     def test_price_update_creation(self):
         """Test basic PriceUpdate creation."""
-        update = PriceUpdate(ticker="AAPL", price=190.50, previous_price=190.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=190.50, previous_price=190.00, day_open=188.00, timestamp=1234567890.0
+        )
         assert update.ticker == "AAPL"
         assert update.price == 190.50
         assert update.previous_price == 190.00
+        assert update.day_open == 188.00
         assert update.timestamp == 1234567890.0
 
     def test_change_calculation(self):
         """Test price change calculation."""
-        update = PriceUpdate(ticker="AAPL", price=190.50, previous_price=190.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=190.50, previous_price=190.00, day_open=190.00, timestamp=1234567890.0
+        )
         assert update.change == 0.50
 
     def test_change_negative(self):
         """Test negative price change."""
-        update = PriceUpdate(ticker="AAPL", price=189.50, previous_price=190.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=189.50, previous_price=190.00, day_open=190.00, timestamp=1234567890.0
+        )
         assert update.change == -0.50
 
     def test_change_percent_up(self):
         """Test percentage change calculation (up)."""
-        update = PriceUpdate(ticker="AAPL", price=190.00, previous_price=100.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=190.00, previous_price=100.00, day_open=100.00, timestamp=1234567890.0
+        )
         assert update.change_percent == 90.0
 
     def test_change_percent_down(self):
         """Test percentage change calculation (down)."""
-        update = PriceUpdate(ticker="AAPL", price=100.00, previous_price=200.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=100.00, previous_price=200.00, day_open=200.00, timestamp=1234567890.0
+        )
         assert update.change_percent == -50.0
 
     def test_change_percent_zero_previous(self):
         """Test percentage change with zero previous price."""
-        update = PriceUpdate(ticker="AAPL", price=100.00, previous_price=0.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=100.00, previous_price=0.00, day_open=100.00, timestamp=1234567890.0
+        )
         assert update.change_percent == 0.0
+
+    def test_day_change_calculation(self):
+        """Daily change is measured against day_open, not the previous tick."""
+        update = PriceUpdate(
+            ticker="AAPL", price=195.00, previous_price=194.90, day_open=190.00, timestamp=1234567890.0
+        )
+        assert update.day_change == 5.00
+        # Daily % is against the open, independent of the tiny tick delta.
+        assert update.day_change_percent == pytest.approx(2.6316, abs=1e-4)
+
+    def test_day_change_negative(self):
+        """Test negative daily change."""
+        update = PriceUpdate(
+            ticker="AAPL", price=180.00, previous_price=180.10, day_open=190.00, timestamp=1234567890.0
+        )
+        assert update.day_change == -10.00
+        assert update.day_change_percent == pytest.approx(-5.2632, abs=1e-4)
+
+    def test_day_change_percent_zero_open(self):
+        """Test daily percentage change with a zero day_open."""
+        update = PriceUpdate(
+            ticker="AAPL", price=100.00, previous_price=100.00, day_open=0.00, timestamp=1234567890.0
+        )
+        assert update.day_change_percent == 0.0
 
     def test_direction_up(self):
         """Test direction calculation (up)."""
-        update = PriceUpdate(ticker="AAPL", price=191.00, previous_price=190.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=191.00, previous_price=190.00, day_open=190.00, timestamp=1234567890.0
+        )
         assert update.direction == "up"
 
     def test_direction_down(self):
         """Test direction calculation (down)."""
-        update = PriceUpdate(ticker="AAPL", price=189.00, previous_price=190.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=189.00, previous_price=190.00, day_open=190.00, timestamp=1234567890.0
+        )
         assert update.direction == "down"
 
     def test_direction_flat(self):
         """Test direction calculation (flat)."""
-        update = PriceUpdate(ticker="AAPL", price=190.00, previous_price=190.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=190.00, previous_price=190.00, day_open=190.00, timestamp=1234567890.0
+        )
         assert update.direction == "flat"
 
     def test_to_dict(self):
         """Test serialization to dictionary."""
-        update = PriceUpdate(ticker="AAPL", price=190.50, previous_price=190.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=190.50, previous_price=190.00, day_open=188.00, timestamp=1234567890.0
+        )
         result = update.to_dict()
 
         assert result["ticker"] == "AAPL"
         assert result["price"] == 190.50
         assert result["previous_price"] == 190.00
+        assert result["day_open"] == 188.00
         assert result["timestamp"] == 1234567890.0
         assert result["change"] == 0.50
         assert result["change_percent"] == 0.2632  # (0.50 / 190.00) * 100
+        assert result["day_change"] == 2.50  # 190.50 - 188.00
+        assert result["day_change_percent"] == 1.3298  # (2.50 / 188.00) * 100
         assert result["direction"] == "up"
 
     def test_immutability(self):
         """Test that PriceUpdate is immutable."""
-        update = PriceUpdate(ticker="AAPL", price=190.50, previous_price=190.00, timestamp=1234567890.0)
+        update = PriceUpdate(
+            ticker="AAPL", price=190.50, previous_price=190.00, day_open=190.00, timestamp=1234567890.0
+        )
 
         with pytest.raises(AttributeError):
             update.price = 200.00  # Should raise error

--- a/backend/tests/market/test_stream.py
+++ b/backend/tests/market/test_stream.py
@@ -1,0 +1,67 @@
+"""Tests for the SSE streaming generator."""
+
+import json
+from types import SimpleNamespace
+
+from app.market.cache import PriceCache
+from app.market.stream import _generate_events
+
+
+class _FakeRequest:
+    """Minimal stand-in for a FastAPI Request.
+
+    ``is_disconnected()`` returns False for the first ``disconnect_after``
+    calls, then True — letting tests bound the generator loop deterministically.
+    """
+
+    def __init__(self, disconnect_after: int) -> None:
+        self._calls = 0
+        self._disconnect_after = disconnect_after
+        self.client = SimpleNamespace(host="test-client")
+
+    async def is_disconnected(self) -> bool:
+        self._calls += 1
+        return self._calls > self._disconnect_after
+
+
+async def test_emits_retry_then_data_then_stops_on_disconnect():
+    """The stream sends a retry directive, one data frame, then stops cleanly."""
+    cache = PriceCache()
+    cache.update("AAPL", 190.50, day_open=188.00)
+    request = _FakeRequest(disconnect_after=1)
+
+    events = [
+        event
+        async for event in _generate_events(cache, request, interval=0, heartbeat=1000)
+    ]
+
+    assert events[0] == "retry: 1000\n\n"
+    assert events[1].startswith("data: ")
+
+    payload = json.loads(events[1].removeprefix("data: ").strip())
+    assert payload["AAPL"]["price"] == 190.50
+    # The daily-change fields (C1) must be present in the SSE payload.
+    assert payload["AAPL"]["day_open"] == 188.00
+    assert "day_change_percent" in payload["AAPL"]
+
+    # Disconnect after the first data frame → no further events.
+    assert len(events) == 2
+
+
+async def test_data_sent_once_then_heartbeat_when_version_unchanged():
+    """When prices don't change, the stream emits keep-alive comments, not data."""
+    cache = PriceCache()
+    cache.update("AAPL", 190.50)
+    request = _FakeRequest(disconnect_after=3)
+
+    # heartbeat=0 → a keep-alive is due on any iteration with no new data.
+    events = [
+        event
+        async for event in _generate_events(cache, request, interval=0, heartbeat=0)
+    ]
+
+    assert events[0] == "retry: 1000\n\n"
+    assert events[1].startswith("data: ")  # initial snapshot, sent once
+    # Subsequent iterations: version unchanged → keep-alive comments only.
+    assert events[2] == ": keep-alive\n\n"
+    assert all(not e.startswith("data: ") for e in events[2:])

--- a/planning/REVIEW.md
+++ b/planning/REVIEW.md
@@ -1,0 +1,159 @@
+# FinAlly Market Data Layer — Code Review
+
+Reviewed files: `backend/app/market/{cache,factory,interface,massive_client,models,seed_prices,simulator,stream}.py`, all of `backend/tests/market/*`, and `backend/pyproject.toml`. The code is generally clean and well-structured, with a sound strategy pattern and good docstrings. The issues below are grouped by severity.
+
+---
+
+## Critical
+
+### C1. `previous_price` is the previous *tick*, but the contract and downstream consumers need a stable reference — and there is NO day_open/prev_close anywhere
+**Status: FIXED.** Added a `day_open` field to `PriceUpdate` with `day_change`/`day_change_percent` properties (the watchlist's "daily change %") and `day_open` carried through `PriceCache.update()` and the SSE payload. Simulator uses the session-open price (first-tick default + carry-forward); Massive uses the snapshot's `day.open`, falling back to `prev_day.close`.
+
+**Files:** `cache.py:31-38`, `models.py:24-37`, `seed_prices.py` (whole file)
+
+The plan's open question (Section 13, item 1) explicitly flags that "daily change %" needs a `day_open`/`prev_close` source. The implementation provides none. `PriceUpdate.previous_price` is the *immediately preceding tick* (`cache.py:31-32`), so `change_percent` (`models.py:24-28`) is a tick-to-tick delta of typically a fraction of a cent — useless as the "daily change %" the watchlist UI requires (PLAN Sections 2 and 10).
+
+This is the single most important gap: the frontend cannot compute the required "daily change %" from anything the cache or SSE event exposes. Either:
+- add a `day_open` (simulator: the seed/session-open price; Massive: the snapshot's `day.open` or `prev_day.close` field, both of which the Polygon snapshot already returns), carry it through `PriceUpdate` and `to_dict()`, and add a `day_change_percent` property; or
+- formally redefine the metric as "change since page load" and compute it frontend-side.
+
+This must be resolved before the frontend agent builds the watchlist, because it changes the SSE payload contract. The Massive snapshot response already contains `todays_change_percent` / `day.open` / `prev_day.close`, so the data is available on the real-data path and is simply being discarded at `massive_client.py:99-108`.
+
+---
+
+## High
+
+### H1. `PriceCache` exposes the `version` counter without holding the lock — torn reads / missed updates on the SSE path
+**Status: FIXED.** Added `PriceCache.snapshot() -> (version, prices-copy)` that reads both under a single lock; the SSE generator now consumes that instead of separate `version` + `get_all()` calls.
+
+**File:** `cache.py:64-67` (read) vs `cache.py:41` (write under lock)
+
+`version` is incremented inside the lock in `update()` but the `version` property reads `self._version` with no lock. In CPython an `int` read is atomic enough not to crash, but the real problem is a memory-ordering / visibility gap against `get_all()`: the SSE generator does `current_version = price_cache.version` (`stream.py:75`) and *then* `price_cache.get_all()` (`stream.py:78`) as two separate locked operations. The version/snapshot pair is not read atomically. A writer can bump the version and write the dict between those two calls, so a client can latch `last_version` to a value whose data it then fails to re-fetch on the next loop because the number didn't change again.
+
+Add a method like `snapshot() -> tuple[int, dict]` that returns `(self._version, dict(self._prices))` under a single lock, and have the SSE loop consume that, instead of reading `version` and `get_all()` separately. This removes the race and the unlocked attribute read.
+
+### H2. SSE generator has no heartbeat/keep-alive; idle connections can be dropped
+**Status: FIXED.** The generator now emits a `: keep-alive` comment when no data has been sent for `heartbeat` seconds (default 15s). Added a `test_stream.py` covering the data-then-heartbeat path (stream previously had zero tests).
+
+**File:** `stream.py:62-85`
+
+On connect the generator yields `retry: 1000` (line 62), then enters the loop. The first data frame is sent on the first iteration because `last_version = -1`, and on reconnect a new generator instance also emits the current snapshot on its first loop iteration — both correct, and this satisfies the PLAN item 18 reconnection requirement.
+
+The concern is that there is **no heartbeat/keep-alive**: if prices stop changing (e.g., Massive returns identical snapshots, or the simulator task died), the connection sends nothing for an unbounded time. Proxies and some browsers will drop an idle event-stream. Add a periodic comment ping (`yield ": keep-alive\n\n"`) every N seconds regardless of version change.
+
+### H3. `is_disconnected()` is the only disconnect path and there is no `finally` cleanup
+**File:** `stream.py:69-85`
+
+Each SSE client runs its own `while True` loop with its own `asyncio.sleep(interval)`. Disconnect detection relies entirely on `request.is_disconnected()`, polled at most every 500ms. There is no `finally:` block to log/clean up on *normal* exit (only `except CancelledError`). Add a `finally:` that handles both the normal-break path (line 73) and the cancelled path so resource accounting/logging is correct.
+
+### H4. Massive snapshot field access assumes a schema/timestamp unit that is unvalidated and likely wrong
+**Status: FIXED (confirmed against the installed SDK).** Verified the real `massive.rest.models`: `LastTrade` has **no** `timestamp` attribute (it has `sip_timestamp`/`participant_timestamp`, in **nanoseconds**) — so the old `snap.last_trade.timestamp / 1000.0` raised `AttributeError` and silently skipped *every* snapshot, meaning the real-data path produced zero updates. Now reads `sip_timestamp` (fallback `participant_timestamp`), divides by 1e9, and pulls `day_open` from `snap.day.open` / `snap.prev_day.close`. Test mocks updated to the real shape, plus new tests for ns conversion, participant fallback, and day-open resolution.
+
+**File:** `massive_client.py:99-108`, `_fetch_snapshots` at `124-128`
+
+The code reads `snap.last_trade.price` and `snap.last_trade.timestamp` and divides the timestamp by `1000.0` assuming **milliseconds** (`massive_client.py:103`). In the Polygon.io snapshot model (which `massive` wraps), the trade timestamp is typically in **nanoseconds**, not milliseconds — so the resulting timestamp would be off by 10^6. The `massive` package is not vendored in the repo, so the exact field/unit could not be confirmed, but this is a real risk: the unit and attribute names are asserted only against a hand-rolled `MagicMock` in `test_massive.py:11-18`, which will pass regardless of the real SDK's shape.
+
+Action: confirm the real `massive` snapshot model's attribute path and timestamp unit against the installed SDK, and add an integration test (or recorded fixture) that exercises the real response shape. As written, the entire real-data path is only tested against a mock that mirrors the code's own assumptions.
+
+### H5. `add_ticker`/`remove_ticker` mutate `self._tickers` with no synchronization against the background task that iterates it
+**Files:** `massive_client.py:66-79` vs `massive_client.py:91, 125`; `simulator.py:242-255` vs `260-270`
+
+For Massive: `add_ticker` does `self._tickers.append(...)` (line 69), an in-place mutation that can race with `len(self._tickers)`/iteration in `_poll_once`. The only true concurrency is the `asyncio.to_thread(self._fetch_snapshots)` window — during which the list can be appended to. `list.append` during another thread's iteration of the same list can raise `RuntimeError: list changed size during iteration` or skip elements.
+
+For the simulator: both `add_ticker` and `_run_loop`/`step()` are coroutines on one loop, and `step()` has no `await`, so they cannot interleave — currently safe *by accident*. It is fragile: any future `await` inside `step` or a move to threads breaks it.
+
+Recommend documenting the single-thread assumption explicitly, and for Massive, snapshot `self._tickers` into a local list before handing it to the thread (`tickers = list(self._tickers); await asyncio.to_thread(self._fetch_snapshots, tickers)`).
+
+---
+
+## Medium
+
+### M1. Simulator per-tick GBM moves are sub-cent and round away to `flat`
+**Files:** `simulator.py:50-57, 207-223`, rounding at `simulator.py:116`
+
+With `DEFAULT_DT ≈ 8.5e-8` and per-tick diffusion `sigma*sqrt(dt)*Z`, a `sigma=0.22` ticker moves on the order of `6e-5` (relative) per tick — i.e. ~1 cent on a $190 stock only occasionally. Rounded to 2 decimals, **most ticks produce no visible change at all**, so `direction` will frequently be `"flat"` and the UI's green/red flash will rarely fire except on event ticks. This under-delivers the "prices flash green/red" UX (PLAN Section 2). Consider scaling `dt` up so per-tick changes are visible, or the demo will look static between rare events.
+
+### M2. Two unseedable global RNGs; tests can't assert deterministic behavior
+**Files:** `simulator.py:84` (`np.random.standard_normal`), `simulator.py:105-107` (`random.random`, `random.uniform`, `random.choice`)
+
+Two independent global RNGs are used, neither seedable. `test_prices_change_over_time` (`test_simulator.py:68-78`) relies on probabilistic non-equality and `test_custom_event_probability` can't assert an event actually occurred. Inject a `numpy.random.Generator` (and use it for both the normals and the event draws) so tests can pin a seed and assert exact behavior, including that an event of 2-5% magnitude fired.
+
+### M3. Cholesky can fail for pathological correlation structures, crashing the loop step
+**File:** `simulator.py:154-172`
+
+`_rebuild_cholesky` builds a correlation matrix from fixed pairwise values (0.6/0.5/0.3) and calls `np.linalg.cholesky` (line 172). The construction does not guarantee positive-definiteness for arbitrary added tickers — a large set with many 0.6 off-diagonals can push the matrix non-PD, making `cholesky` raise `LinAlgError`. This propagates out of `add_ticker` (caught nowhere) or out of `step()` (caught by the broad `except` in `_run_loop` at `simulator.py:268`, which would then silently stop producing correlated updates while logging every tick). Wrap the Cholesky in a try/except that falls back to identity (uncorrelated) decomposition, or nudge the diagonal (`corr += epsilon*I`) to ensure PD.
+
+### M4. `previous_price` semantics on first tick after add — confirm frontend handling
+**Files:** `cache.py:31-37`, `simulator.py:224-228, 245-248`
+
+When a ticker is first seeded, the cache stores `previous_price == price` (flat). The next update computes change against the seed, which is correct. The seeding update bumps `version` and emits a `flat` event for the new ticker (the intended "appears immediately" behavior). Confirm the frontend treats a `flat`/`change=0` first event as "new ticker" and not "no data." Worth a one-line doc note; not a bug.
+
+### M5. Hanging Massive REST call blocks shutdown
+**File:** `massive_client.py:83-97`, `stop()` at `55-64`
+
+`_poll_once` runs the synchronous REST call via `asyncio.to_thread` (line 97). No timeout is configured on `RESTClient`. If that call hangs, `stop()` cancels the task (line 57) but `await self._task` (line 59) blocks until the worker thread returns, because `to_thread` cannot be cancelled. Net effect: shutdown can hang indefinitely on a stuck Massive call. Configure a request timeout on the `RESTClient`, and/or wrap `_poll_once` shutdown with `asyncio.wait_for`. No test covers a hanging poll vs. shutdown.
+
+### M6. No consistent ticker normalization; only Massive normalizes
+**Files:** `massive_client.py:67, 73` (uppercases/strips) vs `simulator.py:120-152` (no normalization), `cache.py:23` (no normalization)
+
+`MassiveDataSource.add_ticker` uppercases and strips; `SimulatorDataSource.add_ticker`/`GBMSimulator.add_ticker` do **not**. So with the simulator, `add_ticker("aapl")` creates a distinct `"aapl"` entry with a random seed price (`simulator.py:151`), diverging from the Massive path and from the seed table. This is PLAN open-question #3. Normalize consistently in both sources (ideally in one shared place), and decide the policy for unknown tickers (the simulator silently invents a `random.uniform(50,300)` price, which the plan flags as needing an explicit rule).
+
+---
+
+## Low
+
+### L1. `event_loop_policy` fixture in `conftest.py` is dead / non-functional
+**File:** `tests/conftest.py:6-11`
+
+With `pytest-asyncio` in `auto` mode, `event_loop_policy` returning the default policy is a no-op. If the intent was to customize loop behavior it does nothing; otherwise remove it to avoid confusion.
+
+### L2. `PriceUpdate.timestamp` default factory never exercised
+**File:** `models.py:16`
+
+`field(default_factory=time.time)` is never used in production (cache always passes `ts`, `cache.py:30`). Harmless, but the time-based default invites accidental "now" timestamps in tests that look deterministic but aren't.
+
+### L3. Price rounded twice (simulator and cache)
+**Files:** `simulator.py:116` (`round(...,2)`) and `cache.py:36` (`round(price,2)`)
+
+The simulator rounds to 2 decimals in `step()`, then the cache rounds again. The Massive path rounds only once (in cache). Pick one layer (recommend cache-only) so both sources behave identically; the simulator's `round` at line 116 is purely cosmetic and duplicative (`self._prices` keeps full precision, which is correct).
+
+### L4. `MassiveDataSource.start` logs `len(tickers)` from the argument, not `self._tickers`
+**File:** `massive_client.py:49-53`
+
+Cosmetic: if `start` is ever called with duplicates, the log count differs from the deduped active set. Use `len(self._tickers)`.
+
+### L5. `start()` double-call is undefined per docs but unguarded
+**Files:** `interface.py:30-31`, `simulator.py:219`, `massive_client.py:41`
+
+Calling `start()` twice silently leaks the first background task (the `self._task` reference is overwritten without cancelling). A cheap guard (`if self._task is not None: raise RuntimeError`) would make the documented contract enforceable.
+
+### L6. `rich` is a runtime dependency only for the demo script
+**File:** `pyproject.toml:12`
+
+`rich` is needed only by `market_data_demo.py`, not the app, yet it ships in the production image's core deps. Move it to an optional `demo` extra to keep the runtime/container lean.
+
+---
+
+## Test coverage gaps
+
+The suite is broad (73 tests) and the cache/models/factory are well covered. Notable gaps:
+
+1. **`stream.py` has essentially no tests.** No test exercises the SSE generator: not the initial `retry:` frame, not version-change gating, not the `is_disconnected` break, not the `to_dict` payload shape, not multi-ticker JSON. Given H1/H2/H3 live here, this is the biggest coverage hole. Add tests driving the async generator with a fake `Request` whose `is_disconnected` flips to `True`, asserting it emits one data frame then stops.
+2. **Massive real-schema risk (H4) is untested.** Every Massive test mocks `_fetch_snapshots` or builds a `MagicMock` snapshot that mirrors the code's own attribute assumptions (`test_massive.py:11-18`), so they cannot catch a wrong field path or wrong timestamp unit. Add at least one test against a captured real response fixture (or pin the SDK model and assert field names).
+3. **Concurrency (H5) untested.** No test adds/removes a ticker while the poll/step loop is running and asserts no `RuntimeError`/lost ticker.
+4. **Cholesky robustness (M3) untested.** No test with many highly-correlated tickers to prove the matrix stays PD.
+5. **Determinism (M2).** Event-shock behavior (`event_probability=1.0` test at `test_simulator_source.py:127-138`) only asserts "starts and stops cleanly" — it never asserts a shock actually moved the price by 2-5%.
+6. **Daily-change (C1).** No test asserts any day-open semantics because the feature doesn't exist — a contract gap, not a missing test per se.
+
+---
+
+## Summary of must-fix before frontend integration
+
+All four resolved (85 tests pass, ruff clean):
+
+- **C1** (day_open/daily-change contract) — ✅ `day_open` + `day_change_percent` wired through cache → `PriceUpdate` → SSE payload.
+- **H4** (Massive timestamp unit + field path) — ✅ confirmed against the SDK; fixed nanosecond conversion and the wrong `last_trade.timestamp` attribute (which had been skipping every snapshot), plus day-open from the snapshot.
+- **H1** (atomic version+snapshot read in the cache) — ✅ added `PriceCache.snapshot()`, SSE consumes it.
+- **H2** (SSE keep-alive heartbeat) — ✅ 15s keep-alive comment; stream test coverage added.
+
+Remaining (not yet addressed): H3, H5, M1–M6, L1–L6, and the other test-coverage gaps.


### PR DESCRIPTION
C1: Add stable day_open + day_change_percent through the cache, PriceUpdate,
    and SSE payload so the watchlist can show a real "daily change %".
H4: Fix Massive snapshot parsing — LastTrade has no `timestamp` attr (it's
    sip_timestamp/participant_timestamp in nanoseconds), so the old code
    silently skipped every snapshot. Convert ns->s and source day_open from
    day.open / prev_day.close. Verified against the installed SDK.
H1: Add PriceCache.snapshot() for an atomic (version, prices) read; SSE uses
    it instead of separate version + get_all() calls (no torn reads).
H2: Emit a 15s keep-alive comment so idle SSE connections aren't reaped.

Tests: add test_stream.py (stream had no coverage); update model/cache/massive tests and mocks to the real SDK shape. 73 -> 85 tests, ruff clean.